### PR TITLE
Handle non-existent addresses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import {
 import Config from './config.json';
 import { OAuthContractMeta } from './oauthMeta';
 
+export class ArcanaAuthException extends Error {}
+
 interface InitParams {
   appID: string;
   redirectUri: string;
@@ -189,6 +191,9 @@ export class AuthProvider {
   private async setAppAddress(): Promise<void> {
     if (!this.appAddress) {
       const appAddress = await getAppAddress(this.params.appID);
+      if (appAddress.length === 0) {
+        throw new ArcanaException('Address non-existent or invalid, are you sure the App ID referenced exists?');
+      }
       this.appAddress = appAddress;
     }
   }


### PR DESCRIPTION
There seems to be a unhandled error mode around https://github.com/arcana-network/auth/blob/main/src/index.ts#L153 .

I think if the app associated with the ID doesn't exist, it returns a empty ('' ) address. The SDK should handle that and throw an error, instead it currently infinite loops continuing to make requests without AppID anyhow.

Easily reproducible by setting the AppID to anything invalid.