### PR TITLE
Add html doc generation commands, version and timestamp details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist/
 .DS_Store
 /types/
+/htmldocs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-@arcana/auth / [Exports](modules.md)
+Auth SDK Reference Guide - v0.0.9-beta5 / [Exports](modules.md)
 
 # Arcana Auth
 

--- a/docs/classes/AuthProvider.md
+++ b/docs/classes/AuthProvider.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / AuthProvider
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / AuthProvider
 
 # Class: AuthProvider
 
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[index.ts:71](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L71)
+[index.ts:71](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L71)
 
 ## Methods
 
@@ -50,7 +50,7 @@ A helper method to get list of available logins
 
 #### Defined in
 
-[index.ts:182](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L182)
+[index.ts:182](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L182)
 
 ___
 
@@ -71,11 +71,11 @@ A method to get public key for other users
 
 `Promise`<`string` \| { `x`: `string` ; `y`: `string`  }\>
 
-returns object or string based on option provided
+returns object or string based on output option provided
 
 #### Defined in
 
-[index.ts:230](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L230)
+[index.ts:229](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L229)
 
 ___
 
@@ -91,7 +91,7 @@ A method to get user info, if logged in
 
 #### Defined in
 
-[index.ts:190](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L190)
+[index.ts:190](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L190)
 
 ___
 
@@ -105,11 +105,9 @@ A helper method to determine whether user is logged in
 
 `boolean`
 
-returns OAuth URL if autoRedirect is set to false
-
 #### Defined in
 
-[index.ts:207](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L207)
+[index.ts:206](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L206)
 
 ___
 
@@ -134,7 +132,7 @@ returns OAuth URL if autoRedirect is set to false, object if withUI is set to fa
 
 #### Defined in
 
-[index.ts:137](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L137)
+[index.ts:137](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L137)
 
 ___
 
@@ -158,7 +156,7 @@ returns OAuth URL if autoRedirect is set to false
 
 #### Defined in
 
-[index.ts:93](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L93)
+[index.ts:93](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L93)
 
 ___
 
@@ -174,7 +172,7 @@ A method to logout the user
 
 #### Defined in
 
-[index.ts:215](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L215)
+[index.ts:214](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L214)
 
 ___
 
@@ -196,7 +194,7 @@ helper function to handle redirect params on popup mode
 
 #### Defined in
 
-[index.ts:60](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L60)
+[index.ts:60](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L60)
 
 ___
 
@@ -218,4 +216,4 @@ helper function to initialize the AuthProvider, should be the starting point
 
 #### Defined in
 
-[index.ts:50](https://github.com/arcana-network/auth/blob/efb5efe/src/index.ts#L50)
+[index.ts:50](https://github.com/arcana-network/auth/blob/ca90bd2/src/index.ts#L50)

--- a/docs/enums/PublicKeyOutput.md
+++ b/docs/enums/PublicKeyOutput.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / PublicKeyOutput
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / PublicKeyOutput
 
 # Enumeration: PublicKeyOutput
 
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[types.ts:13](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L13)
+[types.ts:13](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L13)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[types.ts:12](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L12)
+[types.ts:12](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L12)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[types.ts:14](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L14)
+[types.ts:14](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L14)

--- a/docs/enums/SocialLoginType.md
+++ b/docs/enums/SocialLoginType.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / SocialLoginType
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / SocialLoginType
 
 # Enumeration: SocialLoginType
 
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[types.ts:4](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L4)
+[types.ts:4](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L4)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[types.ts:6](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L6)
+[types.ts:6](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L6)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[types.ts:2](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L2)
+[types.ts:2](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L2)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[types.ts:8](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L8)
+[types.ts:8](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L8)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[types.ts:3](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L3)
+[types.ts:3](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L3)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[types.ts:5](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L5)
+[types.ts:5](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L5)
 
 ___
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[types.ts:7](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L7)
+[types.ts:7](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L7)

--- a/docs/interfaces/GetInfoOutput.md
+++ b/docs/interfaces/GetInfoOutput.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / GetInfoOutput
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / GetInfoOutput
 
 # Interface: GetInfoOutput
 
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[types.ts:29](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L29)
+[types.ts:29](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L29)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[types.ts:31](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L31)
+[types.ts:31](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L31)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[types.ts:30](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L30)
+[types.ts:30](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L30)

--- a/docs/interfaces/InitParams.md
+++ b/docs/interfaces/InitParams.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / InitParams
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / InitParams
 
 # Interface: InitParams
 
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[types.ts:36](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L36)
+[types.ts:36](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L36)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[types.ts:35](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L35)
+[types.ts:35](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L35)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.ts:42](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L42)
+[types.ts:42](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L42)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[types.ts:41](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L41)
+[types.ts:41](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L41)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[types.ts:40](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L40)
+[types.ts:40](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L40)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[types.ts:38](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L38)
+[types.ts:38](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L38)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[types.ts:37](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L37)
+[types.ts:37](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L37)
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[types.ts:39](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L39)
+[types.ts:39](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L39)

--- a/docs/interfaces/KeystoreInput.md
+++ b/docs/interfaces/KeystoreInput.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / KeystoreInput
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / KeystoreInput
 
 # Interface: KeystoreInput
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[types.ts:81](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L81)
+[types.ts:81](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L81)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[types.ts:82](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L82)
+[types.ts:82](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L82)

--- a/docs/interfaces/OtpLoginResponse.md
+++ b/docs/interfaces/OtpLoginResponse.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / OtpLoginResponse
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / OtpLoginResponse
 
 # Interface: OtpLoginResponse
 
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[oauthHandlers.ts:508](https://github.com/arcana-network/auth/blob/efb5efe/src/oauthHandlers.ts#L508)
+[oauthHandlers.ts:508](https://github.com/arcana-network/auth/blob/ca90bd2/src/oauthHandlers.ts#L508)

--- a/docs/interfaces/PasswordlessOptions.md
+++ b/docs/interfaces/PasswordlessOptions.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / PasswordlessOptions
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / PasswordlessOptions
 
 # Interface: PasswordlessOptions
 
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[types.ts:18](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L18)
+[types.ts:18](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L18)

--- a/docs/interfaces/UserInfo.md
+++ b/docs/interfaces/UserInfo.md
@@ -1,4 +1,4 @@
-[@arcana/auth](../README.md) / [Exports](../modules.md) / UserInfo
+[Auth SDK Reference Guide - v0.0.9-beta5](../README.md) / [Exports](../modules.md) / UserInfo
 
 # Interface: UserInfo
 
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[types.ts:23](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L23)
+[types.ts:23](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L23)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[types.ts:22](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L22)
+[types.ts:22](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L22)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[types.ts:24](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L24)
+[types.ts:24](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L24)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[types.ts:25](https://github.com/arcana-network/auth/blob/efb5efe/src/types.ts#L25)
+[types.ts:25](https://github.com/arcana-network/auth/blob/ca90bd2/src/types.ts#L25)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
-[@arcana/auth](README.md) / Exports
+[Auth SDK Reference Guide - v0.0.9-beta5](README.md) / Exports
 
-# @arcana/auth
+# Auth SDK Reference Guide - v0.0.9-beta5
 
 ## Table of contents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "stream-browserify": "^3.0.0",
         "ts-loader": "^9.2.6",
         "typedoc": "^0.22.15",
+        "typedoc-plugin-extras": "^2.2.3",
         "typedoc-plugin-markdown": "^3.12.1",
         "typescript": "^4.4.4",
         "util": "^0.12.4"
@@ -11452,6 +11453,15 @@
         "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
       }
     },
+    "node_modules/typedoc-plugin-extras": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.2.3.tgz",
+      "integrity": "sha512-G4sLPKHO/Q2AB3arxy8Co0jdvO6glGCHtGOUxiiR/Kx1fz+C+/ZbN6Jxu3qi7nyVVW5sX39bW26w+7EjpxicqQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x"
+      }
+    },
     "node_modules/typedoc-plugin-markdown": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.12.1.tgz",
@@ -20522,6 +20532,13 @@
           }
         }
       }
+    },
+    "typedoc-plugin-extras": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.2.3.tgz",
+      "integrity": "sha512-G4sLPKHO/Q2AB3arxy8Co0jdvO6glGCHtGOUxiiR/Kx1fz+C+/ZbN6Jxu3qi7nyVVW5sX39bW26w+7EjpxicqQ==",
+      "dev": true,
+      "requires": {}
     },
     "typedoc-plugin-markdown": {
       "version": "3.12.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:ts": "rimraf dist/ && rimraf types/ && tsc --project tsconfig.json",
     "test": "jest --verbose",
     "docs": "typedoc --options typedoc.json",
+    "htmldocs": "typedoc --options typedochtml.json",
     "test:coverage": "jest --coverage",
     "lint": "eslint ./src",
     "prepare": "husky install",
@@ -62,6 +63,7 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.2.6",
     "typedoc": "^0.22.15",
+    "typedoc-plugin-extras": "^2.2.3",
     "typedoc-plugin-markdown": "^3.12.1",
     "typescript": "^4.4.4",
     "util": "^0.12.4"

--- a/typedochtml.json
+++ b/typedochtml.json
@@ -1,11 +1,11 @@
 {
   "entryPoints": ["src/index.ts"],
   "name": "Auth SDK Reference Guide",
-  "out": "docs",
+  "out": "htmldocs",
   "excludePrivate": true,
   "excludeProtected": true,
   "excludeInternal": true,
-  "includeVersion": true,
-  "hideGenerator": true,
-  "plugin": ["typedoc-plugin-markdown"]
+  "footerDate": true,
+  "footerTime": true,
+  "plugin": ["typedoc-plugin-extras"]
 }


### PR DESCRIPTION
I've reviewed the docs and added a few additional pieces of info.  The layout is not great but we are keeping that at a lower priority for now.  I tried a couple of available typedoc theme plugins but nothing catches the fancy so far.

Note: htmldocs is added as we could use that option instead of integrating md with docusaurus and then generating static docs. Reasons are listed in [#AR-2415](https://team-1624093970686.atlassian.net/browse/AR-2415).